### PR TITLE
Use sys.version_info to determine Python version

### DIFF
--- a/classmate/classmate.py
+++ b/classmate/classmate.py
@@ -24,7 +24,7 @@ def run_local():
         os.nice(19)
     except Exception as error:
         print(error)
-    if sys.version < '3':
+    if sys.version_info[0] < 3:
         import BaseHTTPServer as server
         from CGIHTTPServer import CGIHTTPRequestHandler
     else:


### PR DESCRIPTION
The string `sys.version` should not be used for version checks as there's no guarantee the version number will be at the beginning.
