### PR TITLE
added brython v3 compatibility to glow module

### DIFF
--- a/pyschool/static/external/brython/Lib/site-packages/glow/__init__.py
+++ b/pyschool/static/external/brython/Lib/site-packages/glow/__init__.py
@@ -14,6 +14,7 @@ create_script_tag('/js/glow.1.0.min.js')
 
 #find a better way to do this..
 while 1:
+  glowscript = window.glowscript
   _glowscript=JSObject(glowscript)
 
   try:

--- a/pyschool/static/external/brython/Lib/site-packages/glow/primitive.py
+++ b/pyschool/static/external/brython/Lib/site-packages/glow/primitive.py
@@ -1,169 +1,174 @@
+from browser import window
 from javascript import JSConstructor, JSObject
 from .vector import vec
+from .utils import create_script_tag
+
+create_script_tag('/js/glow.1.0.min.js')
+glowscript = window.glowscript
 
 class primitive:
   def __init__(self, prim, **kwargs):
-      for _key in kwargs.keys():
-          if isinstance(kwargs[_key], vec):
-             kwargs[_key]=kwargs[_key]._vec
+    for _key in kwargs.keys():
+      if isinstance(kwargs[_key], vec):
+        kwargs[_key]=kwargs[_key]._vec
 
-      self._prim=prim(kwargs)
+    self._prim=prim(kwargs)
 
   def rotate(self, **kwargs):
-      if 'axis' in kwargs:
-         #for now lets assume axis is a vector
-         kwargs['axis']=kwargs['axis']._vec
+    if 'axis' in kwargs:
+      #for now lets assume axis is a vector
+      kwargs['axis']=kwargs['axis']._vec
 
-      self._prim.rotate(kwargs)
+    self._prim.rotate(kwargs)
 
   @property
   def pos(self):
-      _v=vec()
-      _v._set_vec(self._prim.pos)
-      return _v
+    _v=vec()
+    _v._set_vec(self._prim.pos)
+    return _v
 
   @pos.setter
   def pos(self, value):
-      if isinstance(value, vec):
-         self._prim.pos=value._vec
-      else:
-         print("Error! pos must be a vector")
+    if isinstance(value, vec):
+      self._prim.pos=value._vec
+    else:
+      print("Error! pos must be a vector")
 
   @property
   def color(self):
-      _v=vec()
-      _v._set_vec(self._prim.color)
-      return _v
+    _v=vec()
+    _v._set_vec(self._prim.color)
+    return _v
 
   @color.setter
   def color(self, value):
-      if isinstance(value, vec):
-         self._prim.color=value._vec
-      else:
-         print("Error! color must be a vec")
+    if isinstance(value, vec):
+      self._prim.color=value._vec
+    else:
+      print("Error! color must be a vec")
 
   @property
   def axis(self):
-      _v=vec()
-      _v._set_vec(self._prim.axis)
-      return _v
+    _v=vec()
+    _v._set_vec(self._prim.axis)
+    return _v
 
   @axis.setter
   def axis(self, value):
-      if isinstance(value, vec):
-         self._prim.axis=value._vec
-      else:
-         print("Error! axis must be a vec")
+    if isinstance(value, vec):
+      self._prim.axis=value._vec
+    else:
+      print("Error! axis must be a vec")
 
   @property
   def size(self):
-      return self._prim.size
+    return self._prim.size
 
   @size.setter
   def size(self, value):
-      self._prim.size=value
+    self._prim.size=value
 
   @property
   def up(self):
-      _v=vec()
-      _v._set_vec(self._prim.up)
-      return _v
+    _v=vec()
+    _v._set_vec(self._prim.up)
+    return _v
 
   @up.setter
   def up(self, value):
-      if isinstance(value, vec):
-         self._prim.up=value._vec
-      else:
-         print("Error! up must be a vec")
+    if isinstance(value, vec):
+      self._prim.up=value._vec
+    else:
+      print("Error! up must be a vec")
 
   @property
   def opacity(self):
-      return self._prim.opacity
+    return self._prim.opacity
 
   @opacity.setter
   def opacity(self, value):
-      self._prim.opacity=value
+    self._prim.opacity=value
 
   @property
   def shininess(self):
-      return self._prim.shininess
+    return self._prim.shininess
 
   @shininess.setter
   def shininess(self, value):
-      self._prim.shininess=value
+    self._prim.shininess=value
 
   @property
   def emissive(self):
-      return self._prim.emissive
+    return self._prim.emissive
 
   @emissive.setter
   def emissive(self, value):
-      self._prim.emissive=value
+    self._prim.emissive=value
 
   @property
   def texture(self):
-      return self._prim.texture
+    return self._prim.texture
 
   @texture.setter
   def texture(self, **kwargs):
-      self._prim.texture=kwargs
+    self._prim.texture=kwargs
 
   @property
   def visible(self):
-      return self._prim.visible
+    return self._prim.visible
 
   @visible.setter
   def visible(self, flag):
-      assert isinstance(flag, bool)
+    assert isinstance(flag, bool)
 
-      self._prim.visble=flag
+    self._prim.visble=flag
 
 class arrow(primitive):
   def __init__(self, **kwargs):
-      primitive.__init__(self, JSConstructor(glowscript.arrow), **kwargs)
+    primitive.__init__(self, JSConstructor(glowscript.arrow), **kwargs)
 
 class box(primitive):
   def __init__(self, **kwargs):
-      primitive.__init__(self, JSConstructor(glowscript.box), **kwargs)
+    primitive.__init__(self, JSConstructor(glowscript.box), **kwargs)
 
 class cone(primitive):
   def __init__(self, **kwargs):
-      primitive.__init__(self, JSConstructor(glowscript.cone), **kwargs)
+    primitive.__init__(self, JSConstructor(glowscript.cone), **kwargs)
 
 class curve(primitive):
   def __init__(self, **kwargs):
-      primitive.__init__(self, JSConstructor(glowscript.curve), **kwargs)
+    primitive.__init__(self, JSConstructor(glowscript.curve), **kwargs)
 
   def push(self, v):
-      if isinstance(v, vec):
-         self._prim.push(v._vec)
-      elif isinstance(v, dict):
-         for _key in v.keys():
-             if isinstance(_key, vec):
-                v[_key]=v[_key]._vec
+    if isinstance(v, vec):
+      self._prim.push(v._vec)
+    elif isinstance(v, dict):
+      for _key in v.keys():
+        if isinstance(_key, vec):
+          v[_key]=v[_key]._vec
 
-         self._prim.push(v)
+      self._prim.push(v)
 
   def append(self, v):
-      self.push(v)
+    self.push(v)
 
 class cylinder(primitive):
   def __init__(self, **kwargs):
-      primitive.__init__(self, JSConstructor(glowscript.cylinder), **kwargs)
+    primitive.__init__(self, JSConstructor(glowscript.cylinder), **kwargs)
 
 class helix(cylinder):
   def __init__(self, **kwargs):
-      primitive.__init__(self, JSConstructor(glowscript.helix), **kwargs)
+    primitive.__init__(self, JSConstructor(glowscript.helix), **kwargs)
 
 class pyramid(primitive):
   def __init__(self, **kwargs):
-      primitive.__init__(self, JSConstructor(glowscript.pyramid), **kwargs)
+    primitive.__init__(self, JSConstructor(glowscript.pyramid), **kwargs)
 
 #class ring(curve):
 
 class sphere(primitive):
   def __init__(self, **kwargs):
-      primitive.__init__(self, JSConstructor(glowscript.sphere), **kwargs)
+    primitive.__init__(self, JSConstructor(glowscript.sphere), **kwargs)
 
 
 #triangle
@@ -188,23 +193,22 @@ class sphere(primitive):
 
 class distinct_light:
   def __init__(self, **kwargs):
-      self._dl=JSConstructor(glowscript.distant_light)(kwargs)
+    self._dl=JSConstructor(glowscript.distant_light)(kwargs)
 
 class local_light:
   def __init__(self, **kwargs):
-      self._ll=JSConstructor(glowscript.local_light)(kwargs)
+    self._ll=JSConstructor(glowscript.local_light)(kwargs)
 
 class draw:
   def __init__(self, **kwargs):
-      self._draw=JSConstructor(glowscript.draw)(kwargs)
+    self._draw=JSConstructor(glowscript.draw)(kwargs)
 
 class label:
   def __init__(self, **kwargs):
-      self._label=JSConstructor(glowscript.label)(kwargs)
+    self._label=JSConstructor(glowscript.label)(kwargs)
 
 def attach_trail(object, **kwargs):
-    if isinstance(object, primitive):
-       JSObject(glowscript.attach_trail)(object._prim, kwargs)
-    else:
-       JSObject(glowscript.attach_trail)(object, kwargs)
-
+  if isinstance(object, primitive):
+    JSObject(glowscript.attach_trail)(object._prim, kwargs)
+  else:
+    JSObject(glowscript.attach_trail)(object, kwargs)

--- a/pyschool/static/external/brython/Lib/site-packages/glow/vector.py
+++ b/pyschool/static/external/brython/Lib/site-packages/glow/vector.py
@@ -1,121 +1,126 @@
+from browser import window
 from javascript import JSConstructor, console
+from .utils import create_script_tag
+
+create_script_tag('/js/glow.1.0.min.js')
+glowscript = window.glowscript
 
 class vec:
   def __init__(self, x=0, y=0, z=0):
-      self._vec=JSConstructor(glowscript.vec)(x,y,z)
+    self._vec=JSConstructor(glowscript.vec)(x,y,z)
 
-      self.add=self.__add__
-      self.sub=self.__sub__
-      self.multiply=self.__mul__
-      self.divide=self.__truediv__=self.__div__
+    self.add=self.__add__
+    self.sub=self.__sub__
+    self.multiply=self.__mul__
+    self.divide=self.__truediv__=self.__div__
 
   #vec should be a glowscript vec, not an instance of this class
   def _set_vec(self, vec):
-      self._vec=vec
+    self._vec=vec
 
   @property
   def x(self):
-      return self._vec.x
+    return self._vec.x
 
   @x.setter
   def x(self, value):
-      self._vec.x=value
+    self._vec.x=value
 
   @property
   def y(self):
-      return self._vec.y
+    return self._vec.y
 
   @y.setter
   def y(self, value):
-      self._vec.y=value
+    self._vec.y=value
 
   @property
   def z(self):
-      return self._vec.z
+    return self._vec.z
 
   @z.setter
   def z(self, value):
-      self._vec.z=value
+    self._vec.z=value
 
   def __add__(self, other):
-      if isinstance(other, vec):
-         _v=vec()
-         _v._set_vec(self._vec.add(other._vec))
-         return _v
+    if isinstance(other, vec):
+      _v=vec()
+      _v._set_vec(self._vec.add(other._vec))
+      return _v
 
-      raise ImplementationError("addition of vec and %s not implemented yet"  % type(other))
+    raise ImplementationError("addition of vec and %s not implemented yet"  % type(other))
 
   def __sub__(self, other):
-      if isinstance(other, vec):
-         _v=vec()
-         _v._set_vec(self._vec.sub(other._vec))
-         return _v
+    if isinstance(other, vec):
+      _v=vec()
+      _v._set_vec(self._vec.sub(other._vec))
+      return _v
 
-      raise ImplementationError("subtraction of vec and %s not is implemented yet"  % type(other))
+    raise ImplementationError("subtraction of vec and %s not is implemented yet"  % type(other))
 
 
   def __mul__(self, other):
-      if isinstance(other, (int, float)):
-         _v=vec()
-         _v._set_vec(self._vec.multiply(other))
-         return _v
+    if isinstance(other, (int, float)):
+      _v=vec()
+      _v._set_vec(self._vec.multiply(other))
+      return _v
 
-      raise ImplementationError("multiplication of vec and %s is not implemented yet"  % type(other))
+    raise ImplementationError("multiplication of vec and %s is not implemented yet"  % type(other))
 
   def __div__(self, other):
-      if isinstance(other, (int, float)):
-         _v=vec()
-         _v._set_vec(self._vec.divide(other))
-         return _v
+    if isinstance(other, (int, float)):
+      _v=vec()
+      _v._set_vec(self._vec.divide(other))
+      return _v
 
-      raise ImplementationError("division of vec and %s is not implemented yet"  % type(other))
+    raise ImplementationError("division of vec and %s is not implemented yet"  % type(other))
 
   def __eq__(self, other):
-      return self._vec.equals(other._vec)
+    return self._vec.equals(other._vec)
 
   def __repr__(self):
-      return self._vec.toString()
+    return self._vec.toString()
 
   def __str__(self):
-      return self._vec.toString()
+    return self._vec.toString()
 
   def comp(self, other):
-      return self._vec.comp(other._vec)
+    return self._vec.comp(other._vec)
 
   def cross(self, other):
-      return self._vec.cross(other._vec)
+    return self._vec.cross(other._vec)
 
   def diff_angle(self, other):
-      return self._vec.diff_angle(other._vec)
+    return self._vec.diff_angle(other._vec)
 
   def dot(self):
-      return self._vec.dot()
+    return self._vec.dot()
 
   def mag(self):
-      return self._vec.mag()
+    return self._vec.mag()
 
   def mag2(self):
-      return self._vec.mag2()
+    return self._vec.mag2()
 
   def norm(self):
-      _v=vec()
-      _v._set_vec(self._vec.norm())
-      return _v
+    _v=vec()
+    _v._set_vec(self._vec.norm())
+    return _v
 
   def proj(self, other):
-      _v=vec()
-      _v._set_vec(self._vec.proj(other._vec))
-      return _v
+    _v=vec()
+    _v._set_vec(self._vec.proj(other._vec))
+    return _v
 
   def random(self):
-      _v = vec()
-      _v._set_vec(self._vec.random())
-      return _v
+    _v = vec()
+    _v._set_vec(self._vec.random())
+    return _v
 
   def rotate(self, **kwargs):
-      _v = vec()
-      _v._set_vec(self._vec.rotate(kwargs))
-      return _v
+    _v = vec()
+    _v._set_vec(self._vec.rotate(kwargs))
+    return _v
 
   def to_glowscript(self):
-      return self._vec
+    return self._vec


### PR DESCRIPTION
I was seeing the updates and it seems glow module s not working fine. I made some adjustments to take into account brython v3 recent changes.

After that I get new errors that seems related only with `glowscript` and the `glow` module:

```
Error: Property 'axis' must be a vec.
  module 'glow.primitive' line 16
    self._prim=prim(kwargs)
  module 'glow.primitive' line 16
    self._prim=prim(kwargs)
```

I couldn't continue with it as I'm not familiar with `glowscript` :-(

Please, review my changes carefully.
